### PR TITLE
Replace cache action with official upstream one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           java-version: 11
       - name: Cache Maven packages
-        uses: alliander/cache@v2.1.3
+        uses: actions/cache@v2.1.3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
The alliander/cache action was being used, but that repository will go offline in the near future. As it was just a fork from actions/cache, you might as well use the one that is official and maintained.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>